### PR TITLE
Pin httpx for TestClient and set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Run tests
+        run: |
+          pytest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+httpx<0.26


### PR DESCRIPTION
## Summary
- add backend requirements with `httpx<0.26`
- create GitHub Actions workflow that installs these dependencies and runs pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846e7e721a483208ff5f06b3706c901