### PR TITLE
Add demo login flow and update seed instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This repository contains the source code for **Seraaj**, a volunteer–organizat
 
 ```bash
 cp .env.sample .env  # adjust values as needed
-cd backend
-pip install -r requirements.txt
-uvicorn app.main:app --reload
+docker-compose up -d && \
+  (cd backend && pip install -r requirements.txt && alembic upgrade head && python seed.py && uvicorn app.main:app --reload) & \
+  (cd frontend && npm install && npm run dev)
 ```
+This installs dependencies, applies migrations, seeds demo data and starts both services.
 
 Run backend tests:
 
@@ -34,11 +35,18 @@ The frontend is built with Vite, React Router and Tailwind CSS.
 
 ### Seeding demo data
 
-Run the seed script to populate the local database with sample data:
+Install backend dependencies then run the seed script to populate the local database with sample data:
 
 ```bash
+pip install -r backend/requirements.txt
 python backend/seed.py
 ```
+
+The seed script creates one account for each user role with password `pass123`:
+
+- Volunteer – `volunteer@example.com`
+- Organization admin – `orgadmin@example.com`
+- Superadmin – `superadmin@example.com`
 
 ### Environment variables
 
@@ -88,27 +96,27 @@ You can try the full stack locally using Docker Compose for Postgres and Redis.
 docker-compose up -d  # starts `db` and `redis` services
 ```
 
-Apply migrations and seed demo data:
+Apply migrations and seed demo data manually if you prefer running the services separately:
 
 ```bash
 cd backend
 alembic upgrade head
-python seed.py  # optional sample data
-```
-
-Start the backend and frontend in separate terminals:
-
-```bash
+python seed.py
 uvicorn app.main:app --reload
 ```
 
+In another terminal:
+
 ```bash
-cd ../frontend
+cd frontend
+npm install
 npm run dev
 ```
 
 The API is now available at `http://localhost:8000/docs` and the web app at
 `http://localhost:5173`.
+
+Use the demo credentials above to sign in as each role and explore the platform.
 
 The frontend includes a dark mode toggle in the top-right corner. Your choice is
 stored in `localStorage`. Superadmins can visit `/settings` to toggle feature

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,13 @@
 from __future__ import with_statement
 import os
+import sys
+from pathlib import Path
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
 from alembic import context
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.models import SQLModel
 from app.db import engine as target_engine

--- a/backend/alembic/versions/d49c28597230_initial.py
+++ b/backend/alembic/versions/d49c28597230_initial.py
@@ -6,6 +6,7 @@ Create Date: 2025-06-09 10:06:59.890862
 """
 from alembic import op
 import sqlalchemy as sa
+import sqlmodel
 
 # revision identifiers, used by Alembic.
 revision = 'd49c28597230'

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,37 @@
+let token: string | null = null;
+
+export function setToken(t: string) {
+  token = t;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('token', t);
+  }
+}
+
+export function getToken(): string | null {
+  if (!token && typeof window !== 'undefined') {
+    token = localStorage.getItem('token');
+  }
+  return token;
+}
+
+export async function login(email: string, password: string): Promise<string> {
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error('Invalid credentials');
+  }
+  const data = await res.json();
+  setToken(data.access_token);
+  return data.access_token as string;
+}
+
+export async function authFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  const t = getToken();
+  if (t) headers.set('Authorization', `Bearer ${t}`);
+  return fetch(input, { ...init, headers });
+}
+

--- a/frontend/src/pages/ApplicantReview.tsx
+++ b/frontend/src/pages/ApplicantReview.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import DataTable from "../components/DataTable";
 import Modal from "../components/Modal";
 import { useState } from "react";
+import { authFetch } from "../api";
 
 interface ApplicantRow {
   id: string;
@@ -16,7 +17,7 @@ export default function ApplicantReview() {
   const { data: applicants = [] } = useQuery<ApplicantRow[]>({
     queryKey: ["apps"],
     queryFn: async () => {
-      const res = await fetch("/api/applicants");
+      const res = await authFetch("/api/applicants");
       if (!res.ok) return [] as ApplicantRow[];
       return res.json();
     },

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FormField from '../components/FormField';
+import { login as apiLogin } from '../api';
 
 export default function Login() {
   const navigate = useNavigate();
@@ -8,13 +9,18 @@ export default function Login() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!email || !password) {
       setError('Email and password required');
       return;
     }
-    navigate('/dashboard');
+    try {
+      await apiLogin(email, password);
+      navigate('/dashboard');
+    } catch {
+      setError('Invalid credentials');
+    }
   }
 
   return (
@@ -45,6 +51,7 @@ export default function Login() {
         <button type="submit" className="mt-2 w-full rounded-2xl bg-brand px-4 py-2 text-white">
           Log In
         </button>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
       </form>
     </main>
   );

--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import OpportunityCard from "../components/OpportunityCard";
+import { authFetch } from "../api";
 
 export default function Opportunities() {
   const [keywords, setKeywords] = useState("");
@@ -14,7 +15,7 @@ export default function Opportunities() {
     queryKey: ["search", keywords],
     queryFn: async () => {
       const params = new URLSearchParams({ q: keywords });
-      const res = await fetch(`/api/opportunity/search?${params.toString()}`);
+      const res = await authFetch(`/api/opportunity/search?${params.toString()}`);
       if (!res.ok) return [] as Result[];
       return res.json();
     },

--- a/frontend/src/pages/OpportunityDetail.tsx
+++ b/frontend/src/pages/OpportunityDetail.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import OpportunityCard from "../components/OpportunityCard";
+import { authFetch } from "../api";
 
 export default function OpportunityDetail() {
   const { id } = useParams();
@@ -15,7 +16,7 @@ export default function OpportunityDetail() {
   const { data } = useQuery<OppDetail | null>({
     queryKey: ["opp", id],
     queryFn: async () => {
-      const res = await fetch(`/api/opportunity/${id}`);
+      const res = await authFetch(`/api/opportunity/${id}`);
       if (!res.ok) return null;
       return res.json();
     },

--- a/frontend/src/pages/OrgDashboard.tsx
+++ b/frontend/src/pages/OrgDashboard.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import DataTable from "../components/DataTable";
+import { authFetch } from "../api";
 
 interface OppRow {
   id: string;
@@ -12,7 +13,7 @@ export default function OrgDashboard() {
   const { data: opps = [] } = useQuery<OppRow[]>({
     queryKey: ["orgOpps"],
     queryFn: async () => {
-      const res = await fetch("/api/org/opportunities");
+      const res = await authFetch("/api/org/opportunities");
       if (!res.ok) return [] as OppRow[];
       return res.json();
     },

--- a/frontend/src/pages/SuperadminSettings.tsx
+++ b/frontend/src/pages/SuperadminSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { authFetch } from '../api';
 
 interface Flags {
   alg_v2: boolean;
@@ -18,12 +19,12 @@ export default function SuperadminSettings() {
   const [health, setHealth] = useState<Health | null>(null);
 
   const fetchFlags = async () => {
-    const res = await fetch('/api/settings/flags');
+    const res = await authFetch('/api/settings/flags');
     if (res.ok) setFlags(await res.json());
   };
 
   const fetchHealth = async () => {
-    const res = await fetch('/api/settings/health');
+    const res = await authFetch('/api/settings/health');
     if (res.ok) setHealth(await res.json());
   };
 
@@ -33,7 +34,7 @@ export default function SuperadminSettings() {
   }, []);
 
   const toggle = async (flag: keyof Flags) => {
-    const res = await fetch(`/api/settings/flags/${flag}`, { method: 'POST' });
+    const res = await authFetch(`/api/settings/flags/${flag}`, { method: 'POST' });
     if (res.ok) fetchFlags();
   };
 

--- a/frontend/src/pages/VolunteerDashboard.tsx
+++ b/frontend/src/pages/VolunteerDashboard.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import ProfileCompletionMeter from "../components/ProfileCompletionMeter";
 import OpportunityCard from "../components/OpportunityCard";
 import DataTable from "../components/DataTable";
+import { authFetch } from "../api";
 
 interface ApplicationRow {
   id: string;
@@ -21,7 +22,7 @@ export default function VolunteerDashboard() {
   const { data: opps = [] } = useQuery<OppRow[]>({
     queryKey: ["opps"],
     queryFn: async () => {
-      const res = await fetch("/api/opportunity/search?match_me=true");
+      const res = await authFetch("/api/opportunity/search?match_me=true");
       if (!res.ok) return [] as OppRow[];
       return res.json();
     },
@@ -31,7 +32,7 @@ export default function VolunteerDashboard() {
   const { data: apps = [] } = useQuery<ApplicationRow[]>({
     queryKey: ["apps"],
     queryFn: async () => {
-      const res = await fetch("/api/applications/me");
+      const res = await authFetch("/api/applications/me");
       if (!res.ok) return [] as ApplicationRow[];
       return res.json();
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary
- instruct quick start to seed database and start services
- mention installing requirements before running seed
- implement `api.ts` helper for JWT auth
- update login page to call backend and show errors
- use `authFetch` across pages so tokens persist
- rewrite `/api` prefix in Vite dev proxy
- load backend package in Alembic env and import sqlmodel

## Testing
- `pip install -r backend/requirements.txt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684f165722d8832092ef6a8e86c9fde2