### PR TITLE
Fix duplicate proxy note

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,7 +24,3 @@ frontend separately.
 There is a dark mode toggle in the corner that persists via `localStorage`.
 Superadmins can access `/settings` to flip feature flags and check system
 health.
-
-During development, API requests to paths starting with `/api` are proxied to
-`http://localhost:8000`. This avoids CORS issues when running the backend and
-frontend separately.


### PR DESCRIPTION
## Summary
- remove extra `/api` proxy explanation in the frontend README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f3150cffc83209fb2912bf112b13e