### PR TITLE
Remove redundant imports in tests

### DIFF
--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -1,6 +1,5 @@
 import uuid
 from fastapi.testclient import TestClient
-from fastapi.testclient import TestClient
 from app.main import app
 from app.db import init_db
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,5 +1,4 @@
 from fastapi.testclient import TestClient
-from fastapi.testclient import TestClient
 from app.main import app
 from app.db import init_db
 


### PR DESCRIPTION
## Summary
- dedupe `TestClient` imports in router & settings tests
- keep coverage passing

## Testing
- `pip install -r backend/requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f3153891c8320b6e133c66e03c64f