### PR TITLE
TASK: conditional init_db

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ pip install -r backend/requirements.txt
 python backend/seed.py
 ```
 
+The application no longer drops tables automatically on startup. To reset the
+database during development you can either run the seed script above or start
+the server with `ENV=dev` which calls `init_db()` on launch.
+
 The seed script creates one account for each user role with password `pass123`:
 
 - Volunteer – `volunteer@example.com`

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+import os
 
 from .db import init_db
 from .routers import (
@@ -24,7 +25,8 @@ app.include_router(settings)
 
 @app.on_event("startup")
 def on_startup():
-    init_db()
+    if os.getenv("ENV") == "dev":
+        init_db()
 
 
 @app.get("/")

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,0 +1,26 @@
+import os
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.main import app
+from app.db import init_db, engine
+from app.models import User, UserRole
+
+
+def test_startup_does_not_drop_tables(monkeypatch):
+    # prepare db with existing row
+    init_db()
+    with Session(engine) as session:
+        user = User(email="keep@example.com", hashed_password="pw", role=UserRole.VOLUNTEER)
+        session.add(user)
+        session.commit()
+        uid = user.id
+
+    # simulate production startup
+    monkeypatch.setenv("ENV", "prod")
+    with TestClient(app):
+        pass
+
+    # ensure row still exists
+    with Session(engine) as session:
+        assert session.get(User, uid) is not None


### PR DESCRIPTION
## Summary
- restrict `init_db()` to dev environment
- document manual seeding in README
- add test verifying tables persist on startup

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f315abbd883208d79722576214681