### PR TITLE
Add frontend routes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from .routers import (
     organization,
     opportunity,
     application,
+    application_extra,
     recognition,
     settings,
 )
@@ -18,6 +19,7 @@ app.include_router(volunteer)
 app.include_router(organization)
 app.include_router(opportunity)
 app.include_router(application)
+app.include_router(application_extra)
 app.include_router(recognition)
 app.include_router(settings)
 

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -2,7 +2,7 @@ from .auth import router as auth
 from .volunteer import router as volunteer
 from .organization import router as organization
 from .opportunity import router as opportunity
-from .application import router as application
+from .application import router as application, extra_router as application_extra
 from .recognition import router as recognition
 from .settings import router as settings
 
@@ -12,6 +12,7 @@ __all__ = [
     "organization",
     "opportunity",
     "application",
+    "application_extra",
     "recognition",
     "settings",
 ]

--- a/backend/app/routers/opportunity.py
+++ b/backend/app/routers/opportunity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 from uuid import UUID
 
@@ -12,6 +12,18 @@ from datetime import date
 from .dependencies import require_role
 
 router = APIRouter(prefix="/opportunity", tags=["opportunity"])
+
+
+@router.get("/{opp_id}", response_model=Opportunity)
+def get_opportunity(
+    opp_id: str,
+    session: Session = Depends(get_session),
+) -> Opportunity:
+    """Return a single opportunity."""
+    opp = session.get(Opportunity, UUID(opp_id))
+    if not opp:
+        raise HTTPException(status_code=404, detail="Opportunity not found")
+    return opp
 
 
 class OpportunityCreate(SQLModel):

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -5,7 +5,6 @@ from app.routers.auth import get_password_hash
 
 from app.db import engine, init_db
 from app.models import User, UserRole, VolunteerProfile, Organization, Opportunity, Application, OpportunityStatus, ApplicationStatus
-from uuid import uuid4
 from random import sample, randint, choice
 
 fake = Faker()
@@ -63,13 +62,22 @@ def create_profiles(session: Session, users: list[User]):
 
 
 def create_orgs(session: Session, count: int = 20) -> list[Organization]:
+    """Create organizations each with their own admin user."""
     orgs = []
     for _ in range(count):
+        admin = User(
+            email=fake.unique.company_email(),
+            hashed_password=get_password_hash("seed"),
+            role=UserRole.ORG_ADMIN,
+        )
+        session.add(admin)
+        session.commit()
+        session.refresh(admin)
         org = Organization(
             name=fake.company(),
             description=fake.bs(),
             website=fake.url(),
-            owner_id=uuid4(),  # placeholder
+            owner_id=admin.id,
         )
         session.add(org)
         orgs.append(org)

--- a/backend/tests/test_frontend_routes.py
+++ b/backend/tests/test_frontend_routes.py
@@ -1,0 +1,95 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.db import init_db
+
+client = TestClient(app)
+
+
+def setup_module():
+    init_db()
+
+
+def _auth_header(email: str, role: str = "VOLUNTEER"):
+    resp = client.post("/auth/register", json={"email": email, "password": "pw", "role": role})
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_opportunity_detail_and_org_list():
+    org_h = _auth_header("org3@example.com", role="ORG_ADMIN")
+    org = client.post("/org", json={"name": "O3", "description": "d"}, headers=org_h)
+    org_id = org.json()["id"]
+    opp = client.post(
+        f"/opportunity/org/{org_id}",
+        json={
+            "title": "T",
+            "description": "d",
+            "skills_required": ["x"],
+            "min_hours": 1,
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-02",
+            "is_remote": True,
+            "status": "OPEN",
+        },
+        headers=org_h,
+    )
+    opp_id = opp.json()["id"]
+
+    detail = client.get(f"/opportunity/{opp_id}")
+    assert detail.status_code == 200
+    assert detail.json()["id"] == opp_id
+
+    opps = client.get("/org/opportunities", headers=org_h)
+    assert opps.status_code == 200
+    assert any(o["id"] == opp_id for o in opps.json())
+
+
+def test_my_apps_and_applicants():
+    org_h = _auth_header("org4@example.com", role="ORG_ADMIN")
+    org = client.post("/org", json={"name": "O4", "description": "d"}, headers=org_h)
+    org_id = org.json()["id"]
+    opp = client.post(
+        f"/opportunity/org/{org_id}",
+        json={
+            "title": "T2",
+            "description": "d",
+            "skills_required": ["x"],
+            "min_hours": 1,
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-02",
+            "is_remote": True,
+            "status": "OPEN",
+        },
+        headers=org_h,
+    )
+    opp_id = opp.json()["id"]
+
+    vol_h = _auth_header("vol3@example.com")
+    uid = client.get("/auth/users/me", headers=vol_h).json()["id"]
+    client.put(
+        "/volunteer/profile",
+        json={
+            "user_id": uid,
+            "full_name": "Name",
+            "skills": ["x"],
+            "interests": [],
+            "languages": ["en"],
+            "location_country": "US",
+            "location_city": "B",
+            "availability_hours": 5,
+        },
+        headers=vol_h,
+    )
+    client.post(
+        f"/application/{opp_id}/apply",
+        json={"volunteer_id": uid, "opportunity_id": opp_id, "status": "PENDING"},
+        headers=vol_h,
+    )
+
+    apps = client.get("/applications/me", headers=vol_h)
+    assert apps.status_code == 200
+    assert len(apps.json()) == 1
+
+    applicants = client.get("/applicants", headers=org_h)
+    assert applicants.status_code == 200
+    assert len(applicants.json()) == 1


### PR DESCRIPTION
## Summary
- expose `/opportunity/{id}` and `/org/opportunities`
- add `/applications/me` and `/applicants` convenience routes
- seed orgs with real admin accounts
- test the new endpoints

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f31b910a08320b98f01ee70db8472