### PR TITLE
Update docs for custom JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ npm run dev
 
 The frontend is built with Vite, React Router and Tailwind CSS.
 
+### Authentication
+
+User registration and login are implemented via in-house JWT endpoints. Tokens are generated with `python-jose` and passwords are hashed using `passlib`. Each token encodes the user's role (`VOLUNTEER`, `ORG_ADMIN`, `SUPERADMIN`).
+
 ### Seeding demo data
 
 Install backend dependencies then run the seed script to populate the local database with sample data:

--- a/docs/adr/0001-stack-and-folder-layout.md
+++ b/docs/adr/0001-stack-and-folder-layout.md
@@ -8,7 +8,7 @@ The Seraaj project needs a clear technology stack and directory structure so con
 
 ## Decision
 - **Backend** uses **FastAPI 0.110** with **SQLModel** for ORM, served by **Uvicorn**. Database migrations run via **Alembic** against **Postgres**.
-- **Authentication** relies on **fastapi-users** issuing JWT tokens with role-based scopes (`VOLUNTEER`, `ORG_ADMIN`, `SUPERADMIN`).
+- **Authentication** is handled in-house using **python-jose** to issue JWT tokens. Passwords are hashed with **passlib**, and tokens encode the user role (`VOLUNTEER`, `ORG_ADMIN`, `SUPERADMIN`).
 - **Matching** jobs run with **Celery** and **Redis**.
 - **Frontend** is a **React 18** application bootstrapped with **Vite** and styled using **Tailwind CSS**. State is managed through **TanStack Query**.
 - **Repository layout**


### PR DESCRIPTION
## Summary
- clarify that authentication is handled in-house using python-jose
- document JWT auth endpoints in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f31c4d50c832091ecc8fe83a3f39b