### PR TITLE
fix: secure frontend routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The frontend is built with Vite, React Router and Tailwind CSS.
 
 ### Authentication
 
-User registration and login are implemented via in-house JWT endpoints. Tokens are generated with `python-jose` and passwords are hashed using `passlib`. Each token encodes the user's role (`VOLUNTEER`, `ORG_ADMIN`, `SUPERADMIN`).
+User registration and login are handled by custom JWT endpoints exposed at `/auth/register` and `/auth/login`. A `/auth/users/me` endpoint returns the authenticated user. Tokens are generated with `python-jose`, passwords hashed with `passlib`, and each token encodes the user's role (`VOLUNTEER`, `ORG_ADMIN`, `SUPERADMIN`).
 
 ### Seeding demo data
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -79,7 +79,7 @@ def create_orgs(
             name=fake.company(),
             description=fake.bs(),
             website=fake.url(),
-            owner_id=admin.id,
+            owner_id=owner.id,
         )
         session.add(org)
         orgs.append(org)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import OpportunityForm from './pages/OpportunityForm';
 import ApplicantReview from './pages/ApplicantReview';
 import SuperadminSettings from './pages/SuperadminSettings';
 import ThemeToggle from './components/ThemeToggle';
+import ProtectedRoute from './components/ProtectedRoute';
 
 export default function App() {
   return (
@@ -19,13 +20,13 @@ export default function App() {
       <Route path="/" element={<Landing />} />
       <Route path="/signup" element={<Signup />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/dashboard" element={<VolunteerDashboard />} />
-      <Route path="/opportunities" element={<Opportunities />} />
-      <Route path="/opportunity/:id" element={<OpportunityDetail />} />
-      <Route path="/org/dashboard" element={<OrgDashboard />} />
-      <Route path="/org/opportunity/new" element={<OpportunityForm />} />
-      <Route path="/org/opportunity/:id/applicants" element={<ApplicantReview />} />
-      <Route path="/settings" element={<SuperadminSettings />} />
+      <Route path="/dashboard" element={<ProtectedRoute><VolunteerDashboard /></ProtectedRoute>} />
+      <Route path="/opportunities" element={<ProtectedRoute><Opportunities /></ProtectedRoute>} />
+      <Route path="/opportunity/:id" element={<ProtectedRoute><OpportunityDetail /></ProtectedRoute>} />
+      <Route path="/org/dashboard" element={<ProtectedRoute><OrgDashboard /></ProtectedRoute>} />
+      <Route path="/org/opportunity/new" element={<ProtectedRoute><OpportunityForm /></ProtectedRoute>} />
+      <Route path="/org/opportunity/:id/applicants" element={<ProtectedRoute><ApplicantReview /></ProtectedRoute>} />
+      <Route path="/settings" element={<ProtectedRoute><SuperadminSettings /></ProtectedRoute>} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
     </>

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -28,7 +28,7 @@ export default function DataTable<T extends { id: string | number }>({ columns, 
           <tr key={row.id} className="hover:bg-gray-50">
             {columns.map((col) => (
               <td key={String(col.key)} className="px-4 py-2">
-                {col.render ? col.render(row) : (row as any)[col.key as keyof T]}
+                {col.render ? col.render(row) : String(row[col.key as keyof T])}
               </td>
             ))}
           </tr>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { getToken } from '../api';
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({ children }: Props) {
+  const token = getToken();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -37,7 +37,7 @@ export default function Opportunities() {
         <p>No matches—try broadening your skills filter.</p>
       ) : (
         <div className="grid gap-4 md:grid-cols-3">
-          {results.map((o: any) => (
+          {results.map((o: Result) => (
             <OpportunityCard key={o.id} title={o.title} orgName={o.orgName} />
           ))}
         </div>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -8,14 +8,26 @@ export default function Signup() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!email || !password) {
       setError('Email and password required');
       return;
     }
-    // stub success
-    navigate('/dashboard');
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || 'Signup failed');
+      }
+      navigate('/login');
+    } catch (err: any) {
+      setError(err.message);
+    }
   }
 
   return (
@@ -47,7 +59,8 @@ export default function Signup() {
         <button type="submit" className="mt-2 w-full rounded-2xl bg-brand px-4 py-2 text-white">
           Create Account
         </button>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
       </form>
-    </main>
+      </main>
   );
 }

--- a/frontend/src/pages/VolunteerDashboard.tsx
+++ b/frontend/src/pages/VolunteerDashboard.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import ProfileCompletionMeter from "../components/ProfileCompletionMeter";
 import OpportunityCard from "../components/OpportunityCard";
 import DataTable from "../components/DataTable";
@@ -13,6 +14,7 @@ interface ApplicationRow {
 }
 
 export default function VolunteerDashboard() {
+  const navigate = useNavigate();
   interface OppRow {
     id: string;
     title: string;
@@ -23,6 +25,11 @@ export default function VolunteerDashboard() {
     queryKey: ["opps"],
     queryFn: async () => {
       const res = await authFetch("/api/opportunity/search?match_me=true");
+      if (res.status === 401) {
+        localStorage.removeItem('token');
+        navigate('/login');
+        return [] as OppRow[];
+      }
       if (!res.ok) return [] as OppRow[];
       return res.json();
     },
@@ -33,6 +40,11 @@ export default function VolunteerDashboard() {
     queryKey: ["apps"],
     queryFn: async () => {
       const res = await authFetch("/api/applications/me");
+      if (res.status === 401) {
+        localStorage.removeItem('token');
+        navigate('/login');
+        return [] as ApplicationRow[];
+      }
       if (!res.ok) return [] as ApplicationRow[];
       return res.json();
     },


### PR DESCRIPTION
## Summary
- protect routes with a new `ProtectedRoute` component
- hook signup form to backend register endpoint
- handle auth failures in dashboard queries
- document JWT endpoints in the README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684f36ab42dc8320b34142e319557dc0