### PR TITLE
UI: handle 401 redirects

### DIFF
--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import OpportunityCard from "../components/OpportunityCard";
 import { authFetch } from "../api";
 
 export default function Opportunities() {
   const [keywords, setKeywords] = useState("");
+  const navigate = useNavigate();
   interface Result {
     id: string;
     title: string;
@@ -16,6 +18,11 @@ export default function Opportunities() {
     queryFn: async () => {
       const params = new URLSearchParams({ q: keywords });
       const res = await authFetch(`/api/opportunity/search?${params.toString()}`);
+      if (res.status === 401) {
+        localStorage.removeItem('token');
+        navigate('/login');
+        return [] as Result[];
+      }
       if (!res.ok) return [] as Result[];
       return res.json();
     },

--- a/frontend/src/pages/OrgDashboard.tsx
+++ b/frontend/src/pages/OrgDashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import DataTable from "../components/DataTable";
 import { authFetch } from "../api";
+import { useNavigate } from "react-router-dom";
 
 interface OppRow {
   id: string;
@@ -10,10 +11,16 @@ interface OppRow {
 }
 
 export default function OrgDashboard() {
+  const navigate = useNavigate();
   const { data: opps = [] } = useQuery<OppRow[]>({
     queryKey: ["orgOpps"],
     queryFn: async () => {
       const res = await authFetch("/api/org/opportunities");
+      if (res.status === 401) {
+        localStorage.removeItem('token');
+        navigate('/login');
+        return [] as OppRow[];
+      }
       if (!res.ok) return [] as OppRow[];
       return res.json();
     },

--- a/frontend/tests/unauth.spec.ts
+++ b/frontend/tests/unauth.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test('401 from search redirects to login', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 't');
+  });
+  await page.route('**/api/opportunity/search**', route => {
+    route.fulfill({ status: 401, body: 'Unauthorized' });
+  });
+  await page.goto('/opportunities');
+  await page.waitForURL('**/login');
+  const token = await page.evaluate(() => localStorage.getItem('token'));
+  expect(token).toBeNull();
+});
+
+test('401 from org dashboard redirects to login', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 't');
+  });
+  await page.route('**/api/org/opportunities', route => {
+    route.fulfill({ status: 401, body: 'Unauthorized' });
+  });
+  await page.goto('/org/dashboard');
+  await page.waitForURL('**/login');
+  const token = await page.evaluate(() => localStorage.getItem('token'));
+  expect(token).toBeNull();
+});


### PR DESCRIPTION
## Summary
- redirect to `/login` and clear token when search or org API calls return 401
- add Playwright tests covering unauthorized responses

## Testing
- `make test`
- `npm run test:e2e` *(fails: browser download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f494fe20483209cbc4f4e71c6ed4e