### PR TITLE
TASK: restrict application create fields

### DIFF
--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -90,7 +90,7 @@ def test_full_flow():
     # apply
     application = client.post(
         f"/application/{opp_id}/apply",
-        json={"volunteer_id": profile.json()["user_id"], "opportunity_id": opp_id, "status": "PENDING"},
+        json={},
         headers=vheaders,
     )
     assert application.status_code == 200

--- a/backend/tests/test_frontend_routes.py
+++ b/backend/tests/test_frontend_routes.py
@@ -82,7 +82,7 @@ def test_my_apps_and_applicants():
     )
     client.post(
         f"/application/{opp_id}/apply",
-        json={"volunteer_id": uid, "opportunity_id": opp_id, "status": "PENDING"},
+        json={},
         headers=vol_h,
     )
 

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -43,7 +43,7 @@ def test_update_status_and_list_apps():
     )
     app_resp = client.post(
         f"/application/{opp_id}/apply",
-        json={"volunteer_id": profile.json()["user_id"], "opportunity_id": opp_id, "status": "PENDING"},
+        json={},
         headers=vol_headers,
     )
     app_id = app_resp.json()["id"]


### PR DESCRIPTION
## Summary
- add `ApplicationCreate` model and use it in the apply route
- adjust router tests for new request payload

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684f49562044832096dc38347bcea239