### PR TITLE
Add example weighted matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Seraaj Matching Prototype
+
+This repository contains a minimal prototype illustrating how weighted skills
+and volunteer proficiency can be used to compute a match score between
+volunteers and opportunities.
+
+## Usage
+
+```python
+from matching import Opportunity, VolunteerProfile, score_opportunity
+
+opportunity = Opportunity(skills_weighted={"python": 5, "sql": 3},
+                          categories_weighted={"data": 2})
+
+volunteer = VolunteerProfile(
+    skill_proficiency={"python": "expert", "sql": "intermediate"},
+    interest_level={"data": "high"},
+)
+
+score = score_opportunity(opportunity, volunteer)
+print(f"Match score: {score:.2f}")
+```
+
+The algorithm assigns points based on the organization's weight for each skill
+and category and the volunteer's proficiency or interest level. The result is a
+normalized score between 0 and 1.

--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -1,0 +1,5 @@
+"""Matching utilities."""
+from .models import Opportunity, VolunteerProfile
+from .matching import score_opportunity
+
+__all__ = ["Opportunity", "VolunteerProfile", "score_opportunity"]

--- a/matching/matching.py
+++ b/matching/matching.py
@@ -1,0 +1,40 @@
+"""Simple matching algorithm using skill weights and proficiency levels."""
+from typing import Dict
+
+from .models import Opportunity, VolunteerProfile
+
+PROFICIENCY_POINTS: Dict[str, int] = {
+    "beginner": 1,
+    "intermediate": 2,
+    "expert": 3,
+}
+
+INTEREST_POINTS: Dict[str, int] = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+
+def score_opportunity(opportunity: Opportunity, volunteer: VolunteerProfile) -> float:
+    """Return a normalized score between 0 and 1."""
+    total = 0
+    max_total = 0
+
+    for skill, weight in opportunity.skills_weighted.items():
+        max_total += weight * PROFICIENCY_POINTS["expert"]
+        proficiency = volunteer.skill_proficiency.get(skill)
+        if proficiency:
+            points = PROFICIENCY_POINTS.get(proficiency.lower(), 0)
+            total += weight * points
+
+    for category, weight in opportunity.categories_weighted.items():
+        max_total += weight * INTEREST_POINTS["high"]
+        interest = volunteer.interest_level.get(category)
+        if interest:
+            points = INTEREST_POINTS.get(interest.lower(), 0)
+            total += weight * points
+
+    if max_total == 0:
+        return 0.0
+    return total / max_total

--- a/matching/models.py
+++ b/matching/models.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from typing import Dict
+
+@dataclass
+class Opportunity:
+    """Represents an opportunity with weighted required skills."""
+    # mapping from skill name to weight (1-5)
+    skills_weighted: Dict[str, int] = field(default_factory=dict)
+    # mapping from category name to required interest weight (optional)
+    categories_weighted: Dict[str, int] = field(default_factory=dict)
+
+@dataclass
+class VolunteerProfile:
+    """Represents a volunteer with proficiency and interests."""
+    # mapping from skill name to proficiency (beginner/intermediate/expert)
+    skill_proficiency: Dict[str, str] = field(default_factory=dict)
+    # mapping from category name to interest level (low/medium/high)
+    interest_level: Dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add prototype `matching` module with simple algorithm
- include dataclasses for Opportunity and VolunteerProfile
- expose scoring API via `__init__`
- document usage in new README

## Testing
- `python -m py_compile matching/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e93966fc88320a4a588de3b0ee068