### PR TITLE
Add basic skill path prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Seraaj Prototype
+
+This repository contains a minimal prototype for managing volunteer skill development.
+
+It provides basic classes and logic to suggest opportunities and external learning resources based on desired skills.
+
+Run tests with `pytest`.

--- a/models.py
+++ b/models.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+@dataclass
+class Opportunity:
+    id: int
+    title: str
+    skills_required: List[str]
+
+@dataclass
+class LearningResource:
+    skill: str
+    url: str
+
+@dataclass
+class VolunteerProfile:
+    id: int
+    name: str
+    desired_skills: List[str] = field(default_factory=list)
+    completed_opportunities: List[int] = field(default_factory=list)
+
+
+def suggest_learning_path(
+    volunteer: VolunteerProfile,
+    opportunities: List[Opportunity],
+    resources: List[LearningResource],
+) -> Dict[str, List[str]]:
+    """Return opportunity titles and resource URLs matching desired skills."""
+    opp_matches = []
+    res_matches = []
+    desired_set = set(map(str.lower, volunteer.desired_skills))
+
+    for opp in opportunities:
+        if desired_set.intersection(map(str.lower, opp.skills_required)):
+            if opp.id not in volunteer.completed_opportunities:
+                opp_matches.append(opp.title)
+
+    for res in resources:
+        if res.skill.lower() in desired_set:
+            res_matches.append(res.url)
+
+    return {"opportunities": opp_matches, "resources": res_matches}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from models import Opportunity, VolunteerProfile, LearningResource, suggest_learning_path
+
+
+def test_suggest_learning_path():
+    vol = VolunteerProfile(id=1, name="Alice", desired_skills=["python", "design"])
+    opps = [
+        Opportunity(id=1, title="Python Mentor", skills_required=["Python", "teaching"]),
+        Opportunity(id=2, title="Graphic Design", skills_required=["design"]),
+        Opportunity(id=3, title="Marketing", skills_required=["seo"]),
+    ]
+    resources = [
+        LearningResource(skill="python", url="https://example.com/python-course"),
+        LearningResource(skill="design", url="https://example.com/design-guide"),
+        LearningResource(skill="cooking", url="https://example.com/cooking"),
+    ]
+
+    result = suggest_learning_path(vol, opps, resources)
+    assert "Python Mentor" in result["opportunities"]
+    assert "Graphic Design" in result["opportunities"]
+    assert "Marketing" not in result["opportunities"]
+    assert "https://example.com/python-course" in result["resources"]
+    assert "https://example.com/design-guide" in result["resources"]
+    assert "https://example.com/cooking" not in result["resources"]


### PR DESCRIPTION
## Summary
- add README describing skill development prototype
- implement `suggest_learning_path` with dataclasses
- add unit test to exercise the matching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e93b51b908320be7bddd2bfcd4846