### PR TITLE
Add contextual matching and recommendation utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Seraaj Matching Prototype
+
+This repository contains a minimal prototype illustrating how weighted skills,
+volunteer proficiency, availability, and location can be used to compute a
+match score between volunteers and opportunities. It also exposes simple
+recommendation helpers and a feedback store.
+
+## Usage
+
+```python
+from matching import (
+    Location,
+    Opportunity,
+    VolunteerProfile,
+    score_opportunity,
+    recommend_opportunities,
+)
+
+opportunity = Opportunity(
+    skills_weighted={"python": 5, "sql": 3},
+    categories_weighted={"data": 2},
+    availability_required={"mon": ["am"]},
+    location=Location(40.0, -75.0),
+)
+
+volunteer = VolunteerProfile(
+    skill_proficiency={"python": "expert", "sql": "intermediate"},
+    interest_level={"data": "high"},
+    availability={"mon": ["am", "pm"]},
+    preferred_location=Location(40.1, -75.1),
+)
+
+score = score_opportunity(opportunity, volunteer)
+print(f"Match score: {score:.2f}")
+
+# Recommend the best opportunities for the volunteer
+recommended = recommend_opportunities(volunteer, [opportunity])
+print(recommended)
+```
+
+The algorithm considers weighted skills, interest categories, availability,
+and proximity to produce a final score between 0 and 1.

--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -1,0 +1,20 @@
+"""Matching utilities."""
+from .models import Location, Opportunity, VolunteerProfile
+from .matching import (
+    FEEDBACK_STORE,
+    MatchFeedback,
+    recommend_opportunities,
+    recommend_volunteers,
+    score_opportunity,
+)
+
+__all__ = [
+    "Location",
+    "Opportunity",
+    "VolunteerProfile",
+    "score_opportunity",
+    "recommend_opportunities",
+    "recommend_volunteers",
+    "MatchFeedback",
+    "FEEDBACK_STORE",
+]

--- a/matching/matching.py
+++ b/matching/matching.py
@@ -1,0 +1,150 @@
+"""Simple matching algorithm using skill weights, availability, and location."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .models import Location, Opportunity, VolunteerProfile
+
+# scoring constants for proficiency and interest
+PROFICIENCY_POINTS: Dict[str, int] = {
+    "beginner": 1,
+    "intermediate": 2,
+    "expert": 3,
+}
+
+INTEREST_POINTS: Dict[str, int] = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+# Weights used when combining different scoring components
+SKILL_WEIGHT = 0.6
+CATEGORY_WEIGHT = 0.1
+AVAILABILITY_WEIGHT = 0.2
+LOCATION_WEIGHT = 0.1
+
+
+def _availability_score(required: Dict[str, List[str]], available: Dict[str, List[str]]) -> float:
+    """Return fraction of required time blocks the volunteer can satisfy."""
+    required_blocks = sum(len(v) for v in required.values())
+    if required_blocks == 0:
+        return 1.0
+    satisfied = 0
+    for day, blocks in required.items():
+        avail_blocks = set(available.get(day, []))
+        satisfied += len([b for b in blocks if b in avail_blocks])
+    return satisfied / required_blocks
+
+
+def _haversine_distance(loc1: Location, loc2: Location) -> float:
+    """Compute the distance in kilometers between two points."""
+    from math import radians, sin, cos, sqrt, atan2
+
+    R = 6371.0
+    lat1, lon1 = radians(loc1.latitude), radians(loc1.longitude)
+    lat2, lon2 = radians(loc2.latitude), radians(loc2.longitude)
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return R * c
+
+
+def _location_score(opportunity: Opportunity, volunteer: VolunteerProfile, radius_km: float = 50.0) -> float:
+    """Return 1 if distance within radius or remote is allowed."""
+    if opportunity.location is None or volunteer.willing_to_remote:
+        return 1.0
+    if volunteer.preferred_location is None:
+        return 0.0
+    distance = _haversine_distance(opportunity.location, volunteer.preferred_location)
+    return 1.0 if distance <= radius_km else 0.0
+
+
+def score_opportunity(opportunity: Opportunity, volunteer: VolunteerProfile) -> float:
+    """Return a normalized score between 0 and 1 including context."""
+    skill_total = 0.0
+    skill_max = 0.0
+
+    for skill, weight in opportunity.skills_weighted.items():
+        skill_max += weight * PROFICIENCY_POINTS["expert"]
+        proficiency = volunteer.skill_proficiency.get(skill)
+        if proficiency:
+            points = PROFICIENCY_POINTS.get(proficiency.lower(), 0)
+            skill_total += weight * points
+
+    category_total = 0.0
+    category_max = 0.0
+    for category, weight in opportunity.categories_weighted.items():
+        category_max += weight * INTEREST_POINTS["high"]
+        interest = volunteer.interest_level.get(category)
+        if interest:
+            points = INTEREST_POINTS.get(interest.lower(), 0)
+            category_total += weight * points
+
+    skill_score = skill_total / skill_max if skill_max else 0.0
+    category_score = category_total / category_max if category_max else 0.0
+
+    availability_score = _availability_score(
+        opportunity.availability_required, volunteer.availability
+    )
+    location_score = _location_score(opportunity, volunteer)
+
+    # weighted combination
+    final_score = (
+        SKILL_WEIGHT * skill_score
+        + CATEGORY_WEIGHT * category_score
+        + AVAILABILITY_WEIGHT * availability_score
+        + LOCATION_WEIGHT * location_score
+    )
+    return max(0.0, min(1.0, final_score))
+
+
+def recommend_opportunities(
+    volunteer: VolunteerProfile, opportunities: Iterable[Opportunity], limit: int = 5
+) -> List[Tuple[Opportunity, float]]:
+    """Return top matching opportunities for a volunteer."""
+    scored = [
+        (opp, score_opportunity(opp, volunteer)) for opp in opportunities
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:limit]
+
+
+def recommend_volunteers(
+    opportunity: Opportunity, volunteers: Iterable[VolunteerProfile], limit: int = 5
+) -> List[Tuple[VolunteerProfile, float]]:
+    """Return top matching volunteers for an opportunity."""
+    scored = [
+        (vol, score_opportunity(opportunity, vol)) for vol in volunteers
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:limit]
+
+
+@dataclass
+class MatchFeedback:
+    """Feedback for a completed match."""
+
+    match_id: str
+    rating: int  # 1-5
+    comment: str = ""
+
+
+class FeedbackStore:
+    """In-memory store of feedback for demonstration purposes."""
+
+    def __init__(self) -> None:
+        self._data: List[MatchFeedback] = []
+
+    def record(self, feedback: MatchFeedback) -> None:
+        self._data.append(feedback)
+
+    def average_rating(self) -> float:
+        if not self._data:
+            return 0.0
+        return sum(f.rating for f in self._data) / len(self._data)
+
+
+FEEDBACK_STORE = FeedbackStore()

--- a/matching/models.py
+++ b/matching/models.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Optional
+
+
+@dataclass
+class Location:
+    """Simple geographic coordinate."""
+    latitude: float
+    longitude: float
+
+
+@dataclass
+class Opportunity:
+    """Represents an opportunity with additional context."""
+
+    # mapping from skill name to weight (1-5)
+    skills_weighted: Dict[str, int] = field(default_factory=dict)
+    # mapping from category name to weight (1-5)
+    categories_weighted: Dict[str, int] = field(default_factory=dict)
+    # availability requirement expressed as mapping day -> list of blocks
+    availability_required: Dict[str, List[str]] = field(default_factory=dict)
+    # location coordinates for in-person work; None for remote
+    location: Optional[Location] = None
+
+
+@dataclass
+class VolunteerProfile:
+    """Represents a volunteer with preferences and proficiency."""
+
+    skill_proficiency: Dict[str, str] = field(default_factory=dict)
+    interest_level: Dict[str, str] = field(default_factory=dict)
+    availability: Dict[str, List[str]] = field(default_factory=dict)
+    preferred_location: Optional[Location] = None
+    willing_to_remote: bool = True


### PR DESCRIPTION
## Summary
- extend `Opportunity` and `VolunteerProfile` dataclasses with availability and location
- implement scoring helpers that account for proficiency, interests, availability, and location
- provide recommendation helpers and an in-memory feedback store
- update package exports and README example

## Testing
- `python -m py_compile matching/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e93966fc88320a4a588de3b0ee068