### PR TITLE
Add learning path and gamification utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# Seraaj Matching Prototype
+
+This repository contains a minimal prototype illustrating how weighted skills,
+volunteer proficiency, availability, and location can be used to compute a
+match score between volunteers and opportunities. It also exposes simple
+recommendation helpers and a feedback store.
+
+## Usage
+
+```python
+from matching import (
+    Location,
+    Opportunity,
+    VolunteerProfile,
+    score_opportunity,
+    recommend_opportunities,
+)
+
+opportunity = Opportunity(
+    skills_weighted={"python": 5, "sql": 3},
+    categories_weighted={"data": 2},
+    availability_required={"mon": ["am"]},
+    location=Location(40.0, -75.0),
+)
+
+volunteer = VolunteerProfile(
+    skill_proficiency={"python": "expert", "sql": "intermediate"},
+    interest_level={"data": "high"},
+    availability={"mon": ["am", "pm"]},
+    preferred_location=Location(40.1, -75.1),
+)
+
+score = score_opportunity(opportunity, volunteer)
+print(f"Match score: {score:.2f}")
+
+# Recommend the best opportunities for the volunteer
+recommended = recommend_opportunities(volunteer, [opportunity])
+print(recommended)
+```
+
+The algorithm considers weighted skills, interest categories, availability,
+and proximity to produce a final score between 0 and 1.
+
+### Learning Paths and Gamification
+
+Additional helpers can suggest opportunities and external resources for a
+volunteer's desired skills, store skill endorsements, and award badges.
+
+```python
+from matching import (
+    LearningResource,
+    suggest_learning_path,
+    ENDORSEMENT_STORE,
+    SkillEndorsement,
+    check_and_award_badges,
+    BADGE_STORE,
+)
+from datetime import datetime
+
+# Recommend learning options
+resources = [LearningResource("python", "https://example.com/python-course")]
+opps, res = suggest_learning_path(volunteer, [opportunity], resources)
+
+# Record an endorsement after opportunity completion
+ENDORSEMENT_STORE.add(
+    SkillEndorsement(
+        volunteer_id="vol1",
+        organization_id="org1",
+        opportunity_id="opp1",
+        skill_name="python",
+        endorsement_date=datetime.utcnow(),
+    )
+)
+
+# Award badges based on hours and endorsements
+check_and_award_badges("vol1", hours=12, endorsement_count=1)
+print(BADGE_STORE.for_volunteer("vol1"))
+```

--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -1,0 +1,42 @@
+"""Matching utilities."""
+from .models import (
+    Badge,
+    LearningResource,
+    Location,
+    Opportunity,
+    SkillEndorsement,
+    VolunteerBadge,
+    VolunteerProfile,
+)
+from .matching import (
+    FEEDBACK_STORE,
+    BADGE_STORE,
+    ENDORSEMENT_STORE,
+    MatchFeedback,
+    check_and_award_badges,
+    leaderboard_by_hours,
+    suggest_learning_path,
+    recommend_opportunities,
+    recommend_volunteers,
+    score_opportunity,
+)
+
+__all__ = [
+    "Location",
+    "Opportunity",
+    "VolunteerProfile",
+    "LearningResource",
+    "SkillEndorsement",
+    "Badge",
+    "VolunteerBadge",
+    "score_opportunity",
+    "recommend_opportunities",
+    "recommend_volunteers",
+    "MatchFeedback",
+    "FEEDBACK_STORE",
+    "ENDORSEMENT_STORE",
+    "BADGE_STORE",
+    "check_and_award_badges",
+    "leaderboard_by_hours",
+    "suggest_learning_path",
+]

--- a/matching/matching.py
+++ b/matching/matching.py
@@ -1,0 +1,256 @@
+"""Simple matching algorithm using skill weights, availability, and location."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .models import (
+    Badge,
+    LearningResource,
+    Location,
+    Opportunity,
+    SkillEndorsement,
+    VolunteerBadge,
+    VolunteerProfile,
+)
+
+# scoring constants for proficiency and interest
+PROFICIENCY_POINTS: Dict[str, int] = {
+    "beginner": 1,
+    "intermediate": 2,
+    "expert": 3,
+}
+
+INTEREST_POINTS: Dict[str, int] = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+# Weights used when combining different scoring components
+SKILL_WEIGHT = 0.6
+CATEGORY_WEIGHT = 0.1
+AVAILABILITY_WEIGHT = 0.2
+LOCATION_WEIGHT = 0.1
+
+
+def _availability_score(required: Dict[str, List[str]], available: Dict[str, List[str]]) -> float:
+    """Return fraction of required time blocks the volunteer can satisfy."""
+    required_blocks = sum(len(v) for v in required.values())
+    if required_blocks == 0:
+        return 1.0
+    satisfied = 0
+    for day, blocks in required.items():
+        avail_blocks = set(available.get(day, []))
+        satisfied += len([b for b in blocks if b in avail_blocks])
+    return satisfied / required_blocks
+
+
+def _haversine_distance(loc1: Location, loc2: Location) -> float:
+    """Compute the distance in kilometers between two points."""
+    from math import radians, sin, cos, sqrt, atan2
+
+    R = 6371.0
+    lat1, lon1 = radians(loc1.latitude), radians(loc1.longitude)
+    lat2, lon2 = radians(loc2.latitude), radians(loc2.longitude)
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return R * c
+
+
+def _location_score(opportunity: Opportunity, volunteer: VolunteerProfile, radius_km: float = 50.0) -> float:
+    """Return 1 if distance within radius or remote is allowed."""
+    if opportunity.location is None or volunteer.willing_to_remote:
+        return 1.0
+    if volunteer.preferred_location is None:
+        return 0.0
+    distance = _haversine_distance(opportunity.location, volunteer.preferred_location)
+    return 1.0 if distance <= radius_km else 0.0
+
+
+def score_opportunity(opportunity: Opportunity, volunteer: VolunteerProfile) -> float:
+    """Return a normalized score between 0 and 1 including context."""
+    skill_total = 0.0
+    skill_max = 0.0
+
+    for skill, weight in opportunity.skills_weighted.items():
+        skill_max += weight * PROFICIENCY_POINTS["expert"]
+        proficiency = volunteer.skill_proficiency.get(skill)
+        if proficiency:
+            points = PROFICIENCY_POINTS.get(proficiency.lower(), 0)
+            skill_total += weight * points
+
+    category_total = 0.0
+    category_max = 0.0
+    for category, weight in opportunity.categories_weighted.items():
+        category_max += weight * INTEREST_POINTS["high"]
+        interest = volunteer.interest_level.get(category)
+        if interest:
+            points = INTEREST_POINTS.get(interest.lower(), 0)
+            category_total += weight * points
+
+    skill_score = skill_total / skill_max if skill_max else 0.0
+    category_score = category_total / category_max if category_max else 0.0
+
+    availability_score = _availability_score(
+        opportunity.availability_required, volunteer.availability
+    )
+    location_score = _location_score(opportunity, volunteer)
+
+    # weighted combination
+    final_score = (
+        SKILL_WEIGHT * skill_score
+        + CATEGORY_WEIGHT * category_score
+        + AVAILABILITY_WEIGHT * availability_score
+        + LOCATION_WEIGHT * location_score
+    )
+    return max(0.0, min(1.0, final_score))
+
+
+def recommend_opportunities(
+    volunteer: VolunteerProfile, opportunities: Iterable[Opportunity], limit: int = 5
+) -> List[Tuple[Opportunity, float]]:
+    """Return top matching opportunities for a volunteer."""
+    scored = [
+        (opp, score_opportunity(opp, volunteer)) for opp in opportunities
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:limit]
+
+
+def recommend_volunteers(
+    opportunity: Opportunity, volunteers: Iterable[VolunteerProfile], limit: int = 5
+) -> List[Tuple[VolunteerProfile, float]]:
+    """Return top matching volunteers for an opportunity."""
+    scored = [
+        (vol, score_opportunity(opportunity, vol)) for vol in volunteers
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:limit]
+
+
+@dataclass
+class MatchFeedback:
+    """Feedback for a completed match."""
+
+    match_id: str
+    rating: int  # 1-5
+    comment: str = ""
+
+
+class FeedbackStore:
+    """In-memory store of feedback for demonstration purposes."""
+
+    def __init__(self) -> None:
+        self._data: List[MatchFeedback] = []
+
+    def record(self, feedback: MatchFeedback) -> None:
+        self._data.append(feedback)
+
+    def average_rating(self) -> float:
+        if not self._data:
+            return 0.0
+        return sum(f.rating for f in self._data) / len(self._data)
+
+
+FEEDBACK_STORE = FeedbackStore()
+
+
+class EndorsementStore:
+    """Simple in-memory storage for skill endorsements."""
+
+    def __init__(self) -> None:
+        self._data: List[SkillEndorsement] = []
+
+    def add(self, endorsement: SkillEndorsement) -> None:
+        self._data.append(endorsement)
+
+    def for_volunteer(self, volunteer_id: str) -> List[SkillEndorsement]:
+        return [e for e in self._data if e.volunteer_id == volunteer_id]
+
+
+ENDORSEMENT_STORE = EndorsementStore()
+
+
+class BadgeStore:
+    """In-memory store for awarded badges."""
+
+    def __init__(self) -> None:
+        self._data: List[VolunteerBadge] = []
+
+    def award(self, badge: VolunteerBadge) -> None:
+        self._data.append(badge)
+
+    def for_volunteer(self, volunteer_id: str) -> List[VolunteerBadge]:
+        return [b for b in self._data if b.volunteer_id == volunteer_id]
+
+
+BADGE_STORE = BadgeStore()
+
+
+HOUR_BADGES: Dict[int, Badge] = {
+    10: Badge(
+        name="10 Hours",
+        description="Completed 10 volunteer hours",
+        image_url="",
+    ),
+    50: Badge(
+        name="50 Hours",
+        description="Completed 50 volunteer hours",
+        image_url="",
+    ),
+}
+
+ENDORSEMENT_BADGE = Badge(
+    name="Endorsed",
+    description="Received first skill endorsement",
+    image_url="",
+)
+
+
+def check_and_award_badges(volunteer_id: str, hours: int, endorsement_count: int) -> None:
+    """Award badges based on hours and endorsements."""
+    for threshold, badge in HOUR_BADGES.items():
+        if hours >= threshold and badge.name not in [b.badge_name for b in BADGE_STORE.for_volunteer(volunteer_id)]:
+            BADGE_STORE.award(
+                VolunteerBadge(
+                    volunteer_id=volunteer_id,
+                    badge_name=badge.name,
+                    award_date=datetime.utcnow(),
+                )
+            )
+
+    if endorsement_count > 0 and ENDORSEMENT_BADGE.name not in [b.badge_name for b in BADGE_STORE.for_volunteer(volunteer_id)]:
+        BADGE_STORE.award(
+            VolunteerBadge(
+                volunteer_id=volunteer_id,
+                badge_name=ENDORSEMENT_BADGE.name,
+                award_date=datetime.utcnow(),
+            )
+        )
+
+
+def leaderboard_by_hours(volunteer_hours: Dict[str, int]) -> List[Tuple[str, int]]:
+    """Return a simple leaderboard sorted by hours volunteered."""
+    return sorted(volunteer_hours.items(), key=lambda p: p[1], reverse=True)
+
+
+def suggest_learning_path(
+    volunteer: VolunteerProfile,
+    opportunities: Iterable[Opportunity],
+    resources: Iterable[LearningResource],
+    limit: int = 5,
+) -> Tuple[List[Opportunity], List[LearningResource]]:
+    """Suggest opportunities and resources to develop desired skills."""
+    relevant_opps = [
+        (opp, score_opportunity(opp, volunteer))
+        for opp in opportunities
+        if any(skill in volunteer.desired_skills for skill in opp.skills_weighted)
+    ]
+    relevant_opps.sort(key=lambda p: p[1], reverse=True)
+    opps = [o for o, _ in relevant_opps[:limit]]
+    res = [r for r in resources if r.skill_name in volunteer.desired_skills]
+    return opps, res

--- a/matching/models.py
+++ b/matching/models.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Location:
+    """Simple geographic coordinate."""
+    latitude: float
+    longitude: float
+
+
+@dataclass
+class Opportunity:
+    """Represents an opportunity with additional context."""
+
+    # mapping from skill name to weight (1-5)
+    skills_weighted: Dict[str, int] = field(default_factory=dict)
+    # mapping from category name to weight (1-5)
+    categories_weighted: Dict[str, int] = field(default_factory=dict)
+    # availability requirement expressed as mapping day -> list of blocks
+    availability_required: Dict[str, List[str]] = field(default_factory=dict)
+    # location coordinates for in-person work; None for remote
+    location: Optional[Location] = None
+
+
+@dataclass
+class VolunteerProfile:
+    """Represents a volunteer with preferences and proficiency."""
+
+    skill_proficiency: Dict[str, str] = field(default_factory=dict)
+    interest_level: Dict[str, str] = field(default_factory=dict)
+    availability: Dict[str, List[str]] = field(default_factory=dict)
+    preferred_location: Optional[Location] = None
+    willing_to_remote: bool = True
+    # skills a volunteer wants to learn/develop
+    desired_skills: List[str] = field(default_factory=list)
+
+
+@dataclass
+class LearningResource:
+    """External resource for learning a specific skill."""
+
+    skill_name: str
+    url: str
+
+
+@dataclass
+class SkillEndorsement:
+    """Endorsement of a volunteer's skill by an organization."""
+
+    volunteer_id: str
+    organization_id: str
+    opportunity_id: str
+    skill_name: str
+    endorsement_date: datetime
+    endorsement_strength: int = 1
+
+
+@dataclass
+class Badge:
+    """Represents a badge that can be awarded to a volunteer."""
+
+    name: str
+    description: str
+    image_url: str
+
+
+@dataclass
+class VolunteerBadge:
+    """A badge awarded to a volunteer."""
+
+    volunteer_id: str
+    badge_name: str
+    award_date: datetime


### PR DESCRIPTION
## Summary
- extend VolunteerProfile with `desired_skills`
- add dataclasses for resources, endorsements and badges
- implement endorsement and badge stores plus helpers for learning paths
- expose new APIs through `__init__`
- document example usage of learning path features in README

## Testing
- `python -m py_compile matching/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e93966fc88320a4a588de3b0ee068