### PR TITLE
Add basic chat prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ print(f"Match score: {score:.2f}")
 The algorithm assigns points based on the organization's weight for each skill
 and category and the volunteer's proficiency or interest level. The result is a
 normalized score between 0 and 1.
+
+## Messaging Prototype
+
+The `chat` package contains a small FastAPI application demonstrating in-platform messaging between volunteers and organizations.
+
+Run the server with:
+
+```bash
+uvicorn chat.server:app
+```
+
+Create a conversation and send messages via the HTTP API or connect to
+`/ws/chat/{conversation_id}` using WebSocket for realtime updates.

--- a/chat/__init__.py
+++ b/chat/__init__.py
@@ -1,0 +1,5 @@
+"""Simple chat prototype using FastAPI."""
+
+from .server import app
+
+__all__ = ["app"]

--- a/chat/models.py
+++ b/chat/models.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+@dataclass
+class Message:
+    """A single chat message."""
+    sender: str
+    content: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+@dataclass
+class Conversation:
+    """A conversation between multiple participants."""
+    id: str
+    participants: List[str] = field(default_factory=list)
+    messages: List[Message] = field(default_factory=list)

--- a/chat/server.py
+++ b/chat/server.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+
+from .models import Conversation, Message
+
+app = FastAPI()
+
+# Simple in-memory stores. These are not persistent and are meant for the prototype.
+conversations: Dict[str, Conversation] = {}
+websocket_connections: Dict[str, List[WebSocket]] = {}
+
+
+class CreateConversationRequest(BaseModel):
+    participants: List[str]
+
+
+class SendMessageRequest(BaseModel):
+    sender: str
+    content: str
+
+
+@app.post("/conversations")
+async def create_conversation(req: CreateConversationRequest):
+    conv_id = str(uuid4())
+    conversation = Conversation(id=conv_id, participants=req.participants)
+    conversations[conv_id] = conversation
+    websocket_connections[conv_id] = []
+    return {"id": conv_id}
+
+
+@app.get("/conversations/{conv_id}")
+async def get_conversation(conv_id: str):
+    conversation = conversations.get(conv_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return {
+        "id": conversation.id,
+        "participants": conversation.participants,
+        "messages": [
+            {
+                "sender": m.sender,
+                "content": m.content,
+                "timestamp": m.timestamp.isoformat(),
+            }
+            for m in conversation.messages
+        ],
+    }
+
+
+@app.post("/conversations/{conv_id}/messages")
+async def send_message(conv_id: str, req: SendMessageRequest):
+    conversation = conversations.get(conv_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    message = Message(sender=req.sender, content=req.content)
+    conversation.messages.append(message)
+
+    for ws in list(websocket_connections.get(conv_id, [])):
+        try:
+            await ws.send_json(
+                {
+                    "sender": message.sender,
+                    "content": message.content,
+                    "timestamp": message.timestamp.isoformat(),
+                }
+            )
+        except WebSocketDisconnect:
+            websocket_connections[conv_id].remove(ws)
+    return {"status": "sent"}
+
+
+@app.websocket("/ws/chat/{conv_id}")
+async def chat_ws(websocket: WebSocket, conv_id: str):
+    await websocket.accept()
+    if conv_id not in conversations:
+        await websocket.close(code=1008)
+        return
+    websocket_connections.setdefault(conv_id, []).append(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            message = Message(sender="anonymous", content=data, timestamp=datetime.utcnow())
+            conversations[conv_id].messages.append(message)
+            for ws in list(websocket_connections[conv_id]):
+                try:
+                    await ws.send_json(
+                        {
+                            "sender": message.sender,
+                            "content": message.content,
+                            "timestamp": message.timestamp.isoformat(),
+                        }
+                    )
+                except WebSocketDisconnect:
+                    websocket_connections[conv_id].remove(ws)
+    except WebSocketDisconnect:
+        websocket_connections[conv_id].remove(websocket)


### PR DESCRIPTION
## Summary
- create `chat` module with dataclasses for `Conversation` and `Message`
- implement `chat.server` FastAPI app with REST and websocket endpoints
- document how to run the messaging prototype in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9a353d4883208c992d4440e53757