### PR TITLE
Add environment setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ docker compose up --build -d && docker compose exec backend python -m app.seed &
 
 Backend API runs on `http://localhost:8000` and the frontend on `http://localhost:5173`.
 
+### Environment Setup
+
+Copy `.env.example` to `.env` and adjust the values for your deployment:
+
+```bash
+cp .env.example .env
+```
+
+For local development you can instead start from `.env.sample`.
+
 ## Usage Examples
 
 ```python


### PR DESCRIPTION
## Summary
- document environment setup in Quickstart section

## Testing
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881242bfb3c8320b4f42ba3e35d0c38