### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update MIT license year to 2025

## Testing
- `make test` *(fails: `docker compose` not a docker command)*

------
https://chatgpt.com/codex/tasks/task_e_68812443e4c08320b5d02c0af71e2afc