### PR TITLE
Add SQLite test fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,9 @@ dev:  ## spin up full stack locally
 seed: ## run seed script against running backend
 	docker compose exec backend python -m app.seed
 
-test: ## run pytest inside backend container
-	docker compose exec backend pytest -q
+test: ## run pytest; use container when available
+	@if docker compose ps -q backend >/dev/null 2>&1; then \
+		docker compose exec backend pytest -q; \
+	else \
+		pytest -q; \
+	fi

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,3 +35,9 @@ Run Celery with beat to compute match scores daily:
 ```bash
 celery -A app.matching worker -B --loglevel=info
 ```
+
+### Testing
+
+`make test` automatically runs the suite inside the Docker container when
+services are running. If Docker isn't available, tests execute locally
+using an SQLite database configured in `backend/tests/conftest.py`.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+
+
+def _docker_service_running(service: str = "db") -> bool:
+    """Return True if the specified docker compose service is running."""
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "ps", "-q", service],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            text=True,
+        )
+        return bool(result.stdout.strip())
+    except Exception:
+        return False
+
+
+def pytest_configure(config):
+    """Fallback to SQLite when the db service is not available."""
+    if not _docker_service_running():
+        os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")


### PR DESCRIPTION
## Summary
- create `backend/tests/conftest.py` for switching to a local SQLite DB when no Docker `db` container is running
- update `Makefile` to run tests directly if containers aren't available
- document local testing fallback in `backend/README.md`

## Testing
- `make test` *(fails: coverage < 90 and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68812e2f867c8320b2abdd3653631bf4