### PR TITLE
Implement alg_v2 embedding scoring

### DIFF
--- a/backend/app/matching.py
+++ b/backend/app/matching.py
@@ -3,13 +3,16 @@ import os
 from celery import Celery
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
+import numpy as np
 from sqlmodel import Session, select
 
 from .db import engine
 from .models import Application, VolunteerProfile, Opportunity
+from .routers.settings import FLAGS
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 celery_app = Celery("matching", broker=REDIS_URL)
+
 
 @celery_app.task
 def compute_match_scores() -> int:
@@ -21,15 +24,24 @@ def compute_match_scores() -> int:
             opp = session.get(Opportunity, app.opportunity_id)
             if not vol or not opp:
                 continue
-            vol_text = " ".join((vol.skills or []) + (vol.interests or []))
-            opp_text = " ".join(opp.skills_required or [])
-            vectorizer = TfidfVectorizer()
-            vec = vectorizer.fit_transform([vol_text, opp_text])
-            score = cosine_similarity(vec[0], vec[1])[0][0]
+            if FLAGS.get("alg_v2"):
+                if vol.embedding is None or opp.embedding is None:
+                    score = 0.0
+                else:
+                    v = np.array(vol.embedding)
+                    o = np.array(opp.embedding)
+                    score = float(v @ o / (np.linalg.norm(v) * np.linalg.norm(o)))
+            else:
+                vol_text = " ".join((vol.skills or []) + (vol.interests or []))
+                opp_text = " ".join(opp.skills_required or [])
+                vectorizer = TfidfVectorizer()
+                vec = vectorizer.fit_transform([vol_text, opp_text])
+                score = cosine_similarity(vec[0], vec[1])[0][0]
             app.match_score = float(score)
             session.add(app)
         session.commit()
         return len(applications)
+
 
 celery_app.conf.beat_schedule = {
     "nightly-match": {

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -1,7 +1,15 @@
 from app.db import init_db, engine
 from app.matching import compute_match_scores
-from app.models import VolunteerProfile, Opportunity, Application, User, UserRole, OpportunityStatus, ApplicationStatus
-from sqlmodel import Session
+from app.models import (
+    VolunteerProfile,
+    Opportunity,
+    Application,
+    User,
+    UserRole,
+    OpportunityStatus,
+    ApplicationStatus,
+)
+from sqlmodel import Session, select
 from datetime import date
 
 
@@ -62,3 +70,65 @@ def test_matching_with_data():
         session.commit()
 
     assert compute_match_scores() == 1
+
+
+def test_matching_embeddings(monkeypatch):
+    """When alg_v2 flag is on, embeddings drive the score."""
+    from app.routers.settings import FLAGS
+
+    init_db()
+    monkeypatch.setitem(FLAGS, "alg_v2", True)
+
+    with Session(engine) as session:
+        user = User(
+            email="ve@example.com", hashed_password="x", role=UserRole.VOLUNTEER
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        profile = VolunteerProfile(
+            user_id=user.id,
+            full_name="V2",
+            skills=["python"],
+            interests=[],
+            languages=["en"],
+            location_country="US",
+            location_city="Z",
+            availability_hours=5,
+            embedding=[1.0] + [0.0] * 767,
+        )
+
+        org = User(email="oe@example.com", hashed_password="x", role=UserRole.ORG_ADMIN)
+        session.add(org)
+        session.commit()
+        session.refresh(org)
+
+        opportunity = Opportunity(
+            org_id=org.id,
+            title="OppE",
+            description="desc",
+            skills_required=["python"],
+            min_hours=1,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 2),
+            is_remote=True,
+            status=OpportunityStatus.OPEN,
+            embedding=[1.0] + [0.0] * 767,
+        )
+        session.add(profile)
+        session.add(opportunity)
+        session.commit()
+
+        application = Application(
+            volunteer_id=user.id,
+            opportunity_id=opportunity.id,
+            status=ApplicationStatus.PENDING,
+        )
+        session.add(application)
+        session.commit()
+
+    assert compute_match_scores() == 1
+    with Session(engine) as session:
+        app_db = session.exec(select(Application)).first()
+        assert app_db.match_score == 1.0


### PR DESCRIPTION
## Summary
- use cosine similarity of embeddings for match scoring when `alg_v2` is enabled
- add test covering embedding scoring branch

## Testing
- `DATABASE_URL=sqlite:///./test.db PYTHONPATH=backend pytest backend/tests/test_matching.py::test_matching_embeddings -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_68812e24919883209ec9612329ad8c72