### PR TITLE
fix: correct vote_post indentation

### DIFF
--- a/matching/matching.py
+++ b/matching/matching.py
@@ -457,7 +457,7 @@ class ForumService:
         )
         return rid
 
-      def vote_post(self, post_id: str, up: bool = True) -> None:
+    def vote_post(self, post_id: str, up: bool = True) -> None:
         post = self.posts.get(post_id)
         if not post:
             return


### PR DESCRIPTION
## Summary
- fix indentation for `vote_post` in `matching.py`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6881352ed7ec832091c6c5997572d704