### PR TITLE
Align database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Copy `.env.example` to `.env` and adjust the values for your deployment:
 cp .env.example .env
 ```
 
+The default Postgres user and password are both `seraaj` as configured in
+`docker-compose.yml`.
+
 For local development you can instead start from `.env.sample`.
 
 ## Usage Examples

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   db:
     image: postgres:16
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: seraaj
+      POSTGRES_PASSWORD: seraaj
       POSTGRES_DB: seraaj
     ports:
       - "5432:5432"


### PR DESCRIPTION
## Summary
- standardize Postgres credentials across `.env` and `docker-compose`
- document default credentials in the README

## Testing
- `pip install -r backend/requirements.txt`
- `make test` *(fails: coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68813512cc6c8320b32ba157201b5fc2