### PR TITLE
Fix apply endpoint initialization

### DIFF
--- a/backend/app/routers/application.py
+++ b/backend/app/routers/application.py
@@ -45,6 +45,7 @@ def apply(
     ).first()
     if duplicate:
         raise HTTPException(status_code=400, detail="Already applied")
+    application = Application(**application_in.dict())
     application.opportunity_id = UUID(opp_id)
     application.volunteer_id = user.id
     session.add(application)


### PR DESCRIPTION
## Summary
- create Application instance from request data before assigning IDs
- adjust router tests for new Application creation logic
- ensure SECRET_KEY set for tests

## Testing
- `pytest backend/tests/test_routers.py::test_update_status_and_list_apps -vv`
- `make test` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6881351c106483208b0409553d057ac9