### PR TITLE
Add Inter font and gradient hero

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    />
     <title>Seraaj</title>
   </head>
   <body class="min-h-screen bg-gray-50 text-gray-900">

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 export default function Landing() {
   return (
     <main className="flex min-h-screen flex-col bg-white">
-      <section className="flex flex-col items-center justify-center bg-brand text-white text-center py-20 px-4">
+      <section className="flex flex-col items-center justify-center bg-ai-gradient text-white text-center py-20 px-4">
         <h1 className="mb-4 text-5xl font-bold">Light the Way for Change</h1>
         <p className="mb-8 max-w-2xl text-lg">
           Connect with vetted volunteer opportunities—instant apply, instant impact.

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,10 +1,17 @@
 import type { Config } from 'tailwindcss';
+import defaultTheme from 'tailwindcss/defaultTheme';
 
 export default {
   darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+      backgroundImage: {
+        'ai-gradient': 'linear-gradient(135deg, #00e0ff 0%, #ae00ff 100%)',
+      },
       colors: {
         brand: {
           DEFAULT: '#087ea4',


### PR DESCRIPTION
## Summary
- load Inter font in frontend index.html
- configure font and gradient utilities in Tailwind
- use new gradient background on Landing page hero

## Testing
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68813687f120832085b5828ee196cc7c