### PR TITLE
Add dark mode styles

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -13,21 +13,21 @@ export interface DataTableProps<T> {
 
 export default function DataTable<T extends { id: string | number }>({ columns, rows }: DataTableProps<T>) {
   return (
-    <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
-      <thead className="bg-gray-50">
+    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-left text-sm">
+      <thead className="bg-gray-50 dark:bg-gray-800">
         <tr>
           {columns.map((col) => (
-            <th key={String(col.key)} className="px-4 py-2 font-medium text-gray-700">
+            <th key={String(col.key)} className="px-4 py-2 font-medium text-gray-700 dark:text-gray-300">
               {col.header}
             </th>
           ))}
         </tr>
       </thead>
-      <tbody className="divide-y divide-gray-100 bg-white">
+      <tbody className="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-900">
         {rows.map((row) => (
-          <tr key={row.id} className="hover:bg-gray-50">
+          <tr key={row.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
             {columns.map((col) => (
-              <td key={String(col.key)} className="px-4 py-2">
+              <td key={String(col.key)} className="px-4 py-2 dark:text-gray-100">
                 {col.render ? col.render(row) : String(row[col.key as keyof T])}
               </td>
             ))}

--- a/frontend/src/components/OpportunityCard.tsx
+++ b/frontend/src/components/OpportunityCard.tsx
@@ -10,7 +10,7 @@ export interface OpportunityCardProps {
 export default function OpportunityCard({ title, orgName, matchScore, onApply }: OpportunityCardProps) {
   return (
     <motion.div
-      className="rounded-2xl bg-white shadow-md p-4 flex flex-col justify-between"
+      className="rounded-2xl bg-white dark:bg-gray-800 dark:text-gray-100 shadow-md p-4 flex flex-col justify-between"
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
     >
@@ -23,7 +23,7 @@ export default function OpportunityCard({ title, orgName, matchScore, onApply }:
       )}
       {onApply && (
         <button
-          className="mt-4 rounded-2xl bg-brand px-4 py-2 text-white hover:bg-brand-dark focus:outline-none"
+          className="mt-4 rounded-2xl bg-brand dark:bg-brand-dark px-4 py-2 text-white hover:bg-brand-dark focus:outline-none"
           onClick={onApply}
         >
           Apply

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
 export function Card({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <div className={`rounded-2xl bg-white ${className ?? ''}`}>{children}</div>;
+  return <div className={`rounded-2xl bg-white dark:bg-gray-800 dark:text-gray-100 ${className ?? ''}`}>{children}</div>;
 }
 
 export function CardContent({ children, className }: { children: React.ReactNode; className?: string }) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,3 +17,26 @@ body,
 .card-shadow {
   @apply shadow-lg shadow-black/5;
 }
+
+@layer components {
+  .card {
+    @apply rounded-2xl bg-white text-gray-900;
+  }
+  .dark .card {
+    @apply bg-gray-800 text-gray-100;
+  }
+
+  .btn {
+    @apply rounded-2xl bg-brand px-4 py-2 text-white hover:bg-brand-dark focus:outline-none;
+  }
+  .dark .btn {
+    @apply bg-brand-dark;
+  }
+
+  .input {
+    @apply rounded border px-3 py-2;
+  }
+  .dark .input {
+    @apply bg-gray-800 border-gray-700 text-gray-100;
+  }
+}


### PR DESCRIPTION
## Summary
- add card/button/input dark-mode styles
- update OpportunityCard and DataTable for dark mode

## Testing
- `make test` *(fails: coverage under 90%)*

------
https://chatgpt.com/codex/tasks/task_e_6881368ce050832084489d02e2016adb