### PR TITLE
Fix SECRET_KEY usage in dependencies

### DIFF
--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -5,12 +5,13 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from sqlmodel import Session
 
+from ..config import get_settings
 from ..db import get_session
 from ..models import User, UserRole
 from uuid import UUID
-import os
 
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret")
+settings = get_settings()
+SECRET_KEY = settings.SECRET_KEY
 ALGORITHM = "HS256"
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")


### PR DESCRIPTION
## Summary
- reference shared `Settings` object in `dependencies`
- keep auth and token validation in sync

## Testing
- `pytest backend/tests/test_routers.py::test_update_status_and_list_apps -q` *(fails: coverage under 90%)*

------
https://chatgpt.com/codex/tasks/task_e_688141570e708320973f9019d3d0d66e