### PR TITLE
Update secret key samples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-SECRET_KEY=changeme
+SECRET_KEY=dev-secret
 DATABASE_URL=postgresql+psycopg2://seraaj:seraaj@db:5432/seraaj
 RESET_ON_START=true
 SEED_DEMO_DATA=true

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The default Postgres user and password are both `seraaj` as configured in
 `docker-compose.yml`.
 
 For local development you can instead start from `.env.sample`.
+Both environment files include a `SECRET_KEY` entry. Ensure the same value is
+used across them (the default is `dev-secret`) so that JWTs issued by the
+backend can be verified.
 
 ## Usage Examples
 
@@ -204,6 +207,10 @@ Pull requests are welcome. Please see `AGENTS.md` for the collaboration workflow
 ## Testing
 
 Ensure Docker is installed before running the test suite. The tests execute inside containers and will fail without Docker.
+
+The backend uses a `SECRET_KEY` environment variable when issuing and decoding
+JWTs. Tests require this to match the value in your `.env` or `.env.sample`
+(default `dev-secret`).
 
 ```bash
 make test


### PR DESCRIPTION
## Summary
- standardize SECRET_KEY in env examples
- explain that tests need the SECRET_KEY

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68814158aff883208dd829a36d8300c5