### PR TITLE
Update seed instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ dev:  ## spin up full stack locally
 	docker compose up --build backend db redis
 
 seed: ## run seed script against running backend
-	docker compose exec backend python -m app.seed
+	docker compose exec backend python seed.py
 
 test: ## run pytest; use container when available
 	@if docker compose ps -q backend >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ Prerequisites: Docker and Node.js 18+.
 
 ```bash
 make dev            # build and start backend, Postgres and Redis
-make seed           # populate demo data
+make seed           # populate demo data (optional)
 (cd frontend && npm install && npm run dev)
 ```
 
 Everything can also be started with a single line:
 
 ```bash
-docker compose up --build -d && docker compose exec backend python -m app.seed && (cd frontend && npm install && npm run dev)
+docker compose up --build -d && docker compose exec backend python seed.py && (cd frontend && npm install && npm run dev)
 ```
+
+Seeding happens automatically on startup when `SEED_DEMO_DATA=true` (set in `.env.example`), so running the script manually is optional.
 
 Backend API runs on `http://localhost:8000` and the frontend on `http://localhost:5173`.
 


### PR DESCRIPTION
## Summary
- change docs to use `python seed.py`
- adjust makefile target to call the new script
- explain auto seeding when `SEED_DEMO_DATA=true`

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688144f630b483208088c7013786fc53