### PR TITLE
Update docs with make dev note

### DIFF
--- a/docs/CODESPACE_GUIDE.md
+++ b/docs/CODESPACE_GUIDE.md
@@ -13,6 +13,9 @@ Follow these steps to launch the app inside a Codespace.
    ```
    This builds the backend and starts Postgres and Redis. The API will be
    available at `http://localhost:${BACKEND_PORT:-8000}`.
+   Note that `make dev` runs continuously, so keep this terminal open. You can
+   open another terminal for the next steps or run `docker compose up -d` to
+   keep the backend running in the background while starting the frontend.
 4. **Run the frontend**:
    ```bash
    cd frontend


### PR DESCRIPTION
## Summary
- clarify that `make dev` continues running
- mention using another terminal or `docker compose up -d`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688161df387c8320abfe932b4054ec6c