### PR TITLE
Update Codespaces port note

### DIFF
--- a/docs/CODESPACE_GUIDE.md
+++ b/docs/CODESPACE_GUIDE.md
@@ -22,7 +22,9 @@ Follow these steps to launch the app inside a Codespace.
    Vite reads `FRONTEND_PORT` and `VITE_BACKEND_URL` from `.env`. By default the
    frontend runs on `http://localhost:${FRONTEND_PORT:-5173}` and proxies API
    requests to the backend.
-5. Open the provided URL in the Codespaces preview or your browser. Log in or
-   sign up to explore the demo data.
+5. When Vite starts you will see a port forwarding prompt in Codespaces. Accept
+   it (or open the **Ports** panel) to expose the frontend on port `5173` and
+   the backend on `${BACKEND_PORT:-8000}`. Open the forwarded URL in the preview
+   or your browser. Log in or sign up to explore the demo data.
 
 Stop the stack with `Ctrl+C` in each terminal or `docker compose down`.


### PR DESCRIPTION
## Summary
- clarify Codespaces port forwarding instructions

## Testing
- `make test` *(fails: Coverage < 90%, multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68816204fda48320b9f3a848e2a71313