### PR TITLE
Update database image to pgvector

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Everything can also be started with a single line:
 docker compose up --build -d && (cd frontend && npm install && npm run dev)
 ```
 
+The `db` service uses the `pgvector/pgvector:pg16` image with host
+authentication set to `scram-sha-256`.
+
 `docker compose up --build` seeds the database automatically because `.env.example` enables `RESET_ON_START` and `SEED_DEMO_DATA`.
 To seed again later, run:
 
@@ -59,6 +62,8 @@ cp .env.example .env
 
 The default Postgres user and password are both `seraaj` as configured in
 `docker-compose.yml`.
+The container provides the pgvector extension via the `pgvector/pgvector:pg16`
+image.
 
 For local development you can instead start from `.env.sample`.
 Both environment files include a `SECRET_KEY` entry. Ensure the same value is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 version: '3.8'
 services:
   db:
-    image: postgres:16
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: seraaj
       POSTGRES_PASSWORD: seraaj
       POSTGRES_DB: seraaj
+      POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary
- switch database service to `pgvector/pgvector:pg16`
- use SCRAM-SHA-256 auth in database init args
- mention pgvector image in Quickstart docs

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68818437f0988320b545ad6cb6386309