### PR TITLE
Update README with mpnet model note

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ docker compose up --build -d && (cd frontend && npm install && npm run dev)
 The `db` service uses the `pgvector/pgvector:pg16` image with host
 authentication set to `scram-sha-256`.
 
-`docker compose up --build` seeds the database automatically because `.env.example` enables `RESET_ON_START` and `SEED_DEMO_DATA`.
+The backend relies on the `sentence-transformers/all-mpnet-base-v2`
+embedding model. The Dockerfile pre-downloads this model so seeding can
+run without internet access.
+
+`docker compose up --build` seeds the database automatically using the
+cached model because `.env.example` enables `RESET_ON_START` and
+`SEED_DEMO_DATA`.
 To seed again later, run:
 
 ```bash

--- a/docs/CODESPACE_GUIDE.md
+++ b/docs/CODESPACE_GUIDE.md
@@ -13,6 +13,10 @@ Start the stack
 # backend + services (runs in watch-mode)
 docker compose up --build backend db redis
 ```
+The backend relies on the `sentence-transformers/all-mpnet-base-v2` model.
+The Dockerfile pre-downloads this model so the seed script can run offline.
+`docker compose up --build` seeds using the cached model because
+`.env.example` enables `RESET_ON_START` and `SEED_DEMO_DATA`.
 Wait until the Ports panel shows 8000 exposed—that means FastAPI is healthy.
 
 In a second terminal:


### PR DESCRIPTION
## Summary
- mention that the backend uses `sentence-transformers/all-mpnet-base-v2`
- explain that Dockerfile preloads the model so seeding can run offline
- clarify that `docker compose up --build` seeds using the cached model
- mirror the note in `docs/CODESPACE_GUIDE.md`

## Testing
- `make test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881a117853c8320ad9445426a6db869