### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+__pycache__/
+node_modules/
+frontend/dist/
+*.pyc


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep the build context small

## Testing
- `pip install pytest-cov`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `docker build -f backend/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6eaca408320adf6148cf19daff2