### PR TITLE
Add worker and frontend services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - APP_ENV=local
       - RESET_ON_START=true
       - SEED_DEMO_DATA=true
+      - REDIS_URL=redis://redis:6379/0
       - BACKEND_PORT=${BACKEND_PORT:-8000}
     volumes:
       - ./backend:/code
@@ -38,6 +39,38 @@ services:
       db:
         condition: service_healthy
       redis:
+        condition: service_started
+
+  worker:
+    build: ./backend
+    command: celery -A app.matching worker -B --loglevel=info
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://seraaj:seraaj@db:5432/seraaj
+      - REDIS_URL=redis://redis:6379/0
+      - APP_ENV=local
+      - SECRET_KEY=changeme
+    volumes:
+      - ./backend:/code
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+  frontend:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm install && npm run dev"
+    environment:
+      - FRONTEND_PORT=${FRONTEND_PORT:-5173}
+      - BACKEND_PORT=${BACKEND_PORT:-8000}
+      - VITE_BACKEND_URL=http://backend:${BACKEND_PORT:-8000}
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "${FRONTEND_PORT:-5173}:${FRONTEND_PORT:-5173}"
+    depends_on:
+      backend:
         condition: service_started
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- add Celery worker service using backend image
- add Node-based frontend service
- expose Redis URL for backend

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6881a6efd07c8320b8c54a354d0defd3