### PR TITLE
Add StatusUpdate model for app status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Seeding happens automatically on startup when `SEED_DEMO_DATA=true` (set in `.en
 
 Backend API runs on `http://localhost:8000` and the frontend on `http://localhost:5173`.
 
+### Updating an Application's Status
+
+Applications are updated via a POST request with a JSON body:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "ACCEPTED"}' \
+  http://localhost:8000/application/<app_id>/status
+```
+
+The `status` field must be one of `PENDING`, `ACCEPTED`, or `REJECTED`.
+
 ### Environment Setup
 
 ➡ **Using GitHub Codespaces?** Follow `docs/CODESPACE_GUIDE.md`

--- a/backend/app/routers/application.py
+++ b/backend/app/routers/application.py
@@ -21,6 +21,12 @@ class ApplicationCreate(SQLModel):
 
     status: ApplicationStatus = ApplicationStatus.PENDING
 
+
+class StatusUpdate(SQLModel):
+    """Payload for updating an application's status."""
+
+    status: ApplicationStatus
+
 router = APIRouter(prefix="/application", tags=["application"])
 # Additional router for paths not under /application prefix
 extra_router = APIRouter(tags=["application"])
@@ -75,7 +81,7 @@ def list_applications(
 @router.post("/{app_id}/status", response_model=Application)
 def update_status(
     app_id: str,
-    status: ApplicationStatus,
+    upd: StatusUpdate,
     session: Session = Depends(get_session),
     user=Depends(require_role("ORG_ADMIN")),
 ) -> Application:
@@ -88,7 +94,7 @@ def update_status(
     org = session.get(Organization, opp.org_id)
     if not org or org.owner_id != user.id:
         raise HTTPException(status_code=403, detail="Not authorized")
-    application.status = status
+    application.status = upd.status
     session.add(application)
     session.commit()
     session.refresh(application)

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -126,7 +126,11 @@ def test_update_status_and_list_apps():
     assert app_resp.json()["volunteer_id"] == vol_id
     assert app_resp.json()["opportunity_id"] == opp_id
     app_id = app_resp.json()["id"]
-    upd = client.post(f"/application/{app_id}/status", params={"status": "ACCEPTED"}, headers=org_headers)
+    upd = client.post(
+        f"/application/{app_id}/status",
+        json={"status": "ACCEPTED"},
+        headers=org_headers,
+    )
     assert upd.status_code == 200
     assert upd.json()["status"] == "ACCEPTED"
     apps = client.get(f"/application/org/{org_id}", headers=org_headers)


### PR DESCRIPTION
## Summary
- accept `StatusUpdate` model in `/application/{app_id}/status`
- adjust tests to send JSON body
- document status update usage in README

## Testing
- `make test` *(fails: pytest-cov not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6f7b0f08320806ab90dcab502f8