### PR TITLE
Improve TF-IDF matching performance

### DIFF
--- a/backend/app/matching.py
+++ b/backend/app/matching.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
 import os
+
+import numpy as np
 from celery import Celery
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
-import numpy as np
 from sqlmodel import Session, select
 
 from .db import engine
@@ -19,9 +21,57 @@ def compute_match_scores() -> int:
     """Compute and persist match scores for all applications."""
     with Session(engine) as session:
         applications = session.exec(select(Application)).all()
+        if not applications:
+            return 0
+
+        vol_ids = {a.volunteer_id for a in applications}
+        opp_ids = {a.opportunity_id for a in applications}
+        volunteers = {
+            v.user_id: v
+            for v in session.exec(
+                select(VolunteerProfile).where(VolunteerProfile.user_id.in_(vol_ids))
+            )
+        }
+        opportunities = {
+            o.id: o
+            for o in session.exec(
+                select(Opportunity).where(Opportunity.id.in_(opp_ids))
+            )
+        }
+
+        updated = 0
+
+        if FLAGS.get("alg_v2"):
+            vol_vecs: dict[str, np.ndarray] = {}
+            opp_vecs: dict[str, np.ndarray] = {}
+        else:
+            texts = [
+                " ".join((vol.skills or []) + (vol.interests or []))
+                for vol in volunteers.values()
+            ] + [" ".join(opp.skills_required or []) for opp in opportunities.values()]
+            vectorizer = TfidfVectorizer()
+            vectorizer.fit(texts)
+            vol_vecs = {
+                vid: vectorizer.transform(
+                    [
+                        " ".join(
+                            (volunteers[vid].skills or [])
+                            + (volunteers[vid].interests or [])
+                        )
+                    ]
+                )
+                for vid in volunteers
+            }
+            opp_vecs = {
+                oid: vectorizer.transform(
+                    [" ".join(opportunities[oid].skills_required or [])]
+                )
+                for oid in opportunities
+            }
+
         for app in applications:
-            vol = session.get(VolunteerProfile, app.volunteer_id)
-            opp = session.get(Opportunity, app.opportunity_id)
+            vol = volunteers.get(app.volunteer_id)
+            opp = opportunities.get(app.opportunity_id)
             if not vol or not opp:
                 continue
             if FLAGS.get("alg_v2"):
@@ -32,15 +82,15 @@ def compute_match_scores() -> int:
                     o = np.array(opp.embedding)
                     score = float(v @ o / (np.linalg.norm(v) * np.linalg.norm(o)))
             else:
-                vol_text = " ".join((vol.skills or []) + (vol.interests or []))
-                opp_text = " ".join(opp.skills_required or [])
-                vectorizer = TfidfVectorizer()
-                vec = vectorizer.fit_transform([vol_text, opp_text])
-                score = cosine_similarity(vec[0], vec[1])[0][0]
+                vol_vec = vol_vecs[app.volunteer_id]
+                opp_vec = opp_vecs[app.opportunity_id]
+                score = cosine_similarity(vol_vec, opp_vec)[0][0]
             app.match_score = float(score)
             session.add(app)
+            updated += 1
+
         session.commit()
-        return len(applications)
+        return updated
 
 
 celery_app.conf.beat_schedule = {

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -132,3 +132,77 @@ def test_matching_embeddings(monkeypatch):
     with Session(engine) as session:
         app_db = session.exec(select(Application)).first()
         assert app_db.match_score == 1.0
+
+
+def test_tfidf_vectorizer_reuse(monkeypatch):
+    """Vectorizer should be fit once and reused across pairs."""
+    from app import matching as m
+
+    init_db()
+
+    calls = {"fit": 0, "transform": 0}
+
+    class CountingVectorizer(m.TfidfVectorizer):
+        def fit(self, raw_documents, y=None):  # type: ignore[override]
+            calls["fit"] += 1
+            return super().fit(raw_documents, y)
+
+        def transform(self, raw_documents):  # type: ignore[override]
+            calls["transform"] += 1
+            return super().transform(raw_documents)
+
+    monkeypatch.setattr(m, "TfidfVectorizer", CountingVectorizer)
+
+    with Session(engine) as session:
+        org = User(
+            email="orgv@example.com", hashed_password="x", role=UserRole.ORG_ADMIN
+        )
+        session.add(org)
+        session.commit()
+        session.refresh(org)
+
+        for i in range(2):
+            user = User(
+                email=f"v{i}@e.com", hashed_password="x", role=UserRole.VOLUNTEER
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+
+            profile = VolunteerProfile(
+                user_id=user.id,
+                full_name="V",
+                skills=["python"],
+                interests=["data"],
+                languages=["en"],
+                location_country="US",
+                location_city="Z",
+                availability_hours=5,
+            )
+            session.add(profile)
+
+            opp = Opportunity(
+                org_id=org.id,
+                title=f"O{i}",
+                description="d",
+                skills_required=["python"],
+                min_hours=1,
+                start_date=date(2025, 1, 1),
+                end_date=date(2025, 1, 2),
+                is_remote=True,
+                status=OpportunityStatus.OPEN,
+            )
+            session.add(opp)
+            session.commit()
+
+            app = Application(
+                volunteer_id=user.id,
+                opportunity_id=opp.id,
+                status=ApplicationStatus.PENDING,
+            )
+            session.add(app)
+            session.commit()
+
+    assert compute_match_scores() == 2
+    assert calls["fit"] == 1
+    assert calls["transform"] == 4


### PR DESCRIPTION
## Summary
- compute volunteer and opportunity TF‑IDF vectors once per run
- reuse a single `TfidfVectorizer` across pairs
- test that the vectorizer is fit only once

## Testing
- `make test` *(fails: coverage 75%)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6fb78908320ba343b0a6c3d5a96