### PR TITLE
Add frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+# build static assets
+ARG VITE_BACKEND_URL=http://localhost:8000
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+RUN npm run build
+
+FROM node:18 AS runner
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=build /app/dist ./dist
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]


### PR DESCRIPTION
## Summary
- provide Dockerfile under `frontend/` to build static assets

## Testing
- `make test` *(fails: coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6fd53148320a20c33f5eadcd7d5