### PR TITLE
Fix closed opportunity apply test

### DIFF
--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -162,6 +162,15 @@ def test_apply_closed_opportunity():
     opp_id = closed_opp.json()["id"]
 
     vol_h, uid = _auth_header("volclosed@example.com")
+    resp = client.post(
+        f"/application/{opp_id}/apply",
+        json={},
+        headers=vol_h,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Opportunity closed"
+
+
 def test_duplicate_application_rejected():
     org_headers, _ = _auth_header("org3@example.com", role="ORG_ADMIN")
     org = client.post("/org", json={"name": "O3", "description": "d"}, headers=org_headers)


### PR DESCRIPTION
## Summary
- assert that applying to a CLOSED opportunity returns `Opportunity closed`
- keep `test_duplicate_application_rejected` separated properly

## Testing
- `make test` *(fails: ResponseValidationError, coverage 74%)*

------
https://chatgpt.com/codex/tasks/task_e_6881bc6afaec8320b0d59cea0eb1ea64